### PR TITLE
Feat: Add TokenRefresher listener that runs before actions are executed

### DIFF
--- a/app/Actions/Workflow/ExecuteWorkflow.php
+++ b/app/Actions/Workflow/ExecuteWorkflow.php
@@ -7,18 +7,20 @@
 
 namespace App\Actions\Workflow;
 
-use App\Actions\WorkflowAction\ExecuteWorkflowAction;
+use App\Events\WorkflowActionTriggered;
 use App\Models\Workflow;
 use App\Models\WorkflowAction;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
+use Illuminate\Queue\SerializesModels;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class ExecuteWorkflow implements ShouldQueue, ShouldQueueAfterCommit
 {
     use AsAction;
     use Queueable;
+    use SerializesModels;
 
     public function handle(Workflow $workflow): void
     {
@@ -29,6 +31,6 @@ class ExecuteWorkflow implements ShouldQueue, ShouldQueueAfterCommit
             ])
             ->orderBy('execution_order');
 
-        $executableActions->each(fn (WorkflowAction $action) => ExecuteWorkflowAction::run($action));
+        $executableActions->each(fn (WorkflowAction $action) => WorkflowActionTriggered::dispatch($action));
     }
 }

--- a/app/Actions/WorkflowAction/ExecuteWorkflowAction.php
+++ b/app/Actions/WorkflowAction/ExecuteWorkflowAction.php
@@ -8,21 +8,20 @@
 namespace App\Actions\WorkflowAction;
 
 use App\Events\WorkflowAction\WorkflowActionExecuted;
+use App\Events\WorkflowActionTriggered;
 use App\Http\Integrations\Workflow\Requests\WorkflowActionRequest;
 use App\Http\Integrations\Workflow\ServiceConnector;
 use App\Models\WorkflowAction;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Http\Request;
+use Illuminate\Queue\SerializesModels;
 use Lorisleiva\Actions\Concerns\AsAction;
 use Saloon\Exceptions\Request\FatalRequestException;
 use Saloon\Exceptions\Request\RequestException;
 
-class ExecuteWorkflowAction implements ShouldQueue, ShouldQueueAfterCommit
+class ExecuteWorkflowAction
 {
     use AsAction;
-    use Queueable;
+    use SerializesModels;
 
     public function handle(WorkflowAction $action): void
     {
@@ -50,6 +49,11 @@ class ExecuteWorkflowAction implements ShouldQueue, ShouldQueueAfterCommit
     public function asJob(WorkflowAction $action): void
     {
         $this->handle($action);
+    }
+
+    public function asListener(WorkflowActionTriggered $actionTriggered): void
+    {
+        $this->handle($actionTriggered->action);
     }
 
     public function asController(Request $request): void

--- a/app/Events/WorkflowActionTriggered.php
+++ b/app/Events/WorkflowActionTriggered.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\WorkflowAction;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class WorkflowActionTriggered
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public WorkflowAction $action) {}
+}

--- a/app/Http/Controllers/WorkflowActionController.php
+++ b/app/Http/Controllers/WorkflowActionController.php
@@ -7,7 +7,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Actions\WorkflowAction\ExecuteWorkflowAction;
+use App\Events\WorkflowActionTriggered;
 use App\Http\Resources\Api\WorkflowActionHistoryResource;
 use App\Models\WorkflowAction;
 use Illuminate\Http\JsonResponse;
@@ -21,7 +21,7 @@ class WorkflowActionController extends Controller
 
     public function execute(WorkflowAction $action): JsonResponse
     {
-        ExecuteWorkflowAction::run($action);
+        WorkflowActionTriggered::dispatch($action);
 
         if (! empty($action->refresh()->latestExecution)) {
             return response()->json(WorkflowActionHistoryResource::make($action->latestExecution));

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -7,8 +7,8 @@
 
 namespace App\Http\Controllers;
 
-use App\Actions\WorkflowAction\ExecuteWorkflowAction;
 use App\Enums\Workflow\Status;
+use App\Events\WorkflowActionTriggered;
 use App\Http\Requests\StoreWorkflowRequest;
 use App\Http\Resources\Api\WorkflowActionHistoryResource;
 use App\Http\Resources\Api\WorkflowResource;
@@ -131,7 +131,7 @@ class WorkflowController extends Controller
     {
         $trigger = $workflow->trigger;
 
-        ExecuteWorkflowAction::run($trigger);
+        WorkflowActionTriggered::dispatch($trigger);
 
         if (! empty($trigger->refresh()->latestExecution)) {
             return response()->json(WorkflowActionHistoryResource::make($trigger->latestExecution));

--- a/app/Http/Integrations/OAuthToken/Connectors/GoogleOAuthConnector.php
+++ b/app/Http/Integrations/OAuthToken/Connectors/GoogleOAuthConnector.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Author: Marc Malha
+ * Version: 1.0
+ */
+
+namespace App\Http\Integrations\OAuthToken\Connectors;
+
+use App\Http\Integrations\OAuthToken\OAuthRefresherContract;
+use App\Models\Service;
+use Saloon\Helpers\OAuth2\OAuthConfig;
+use Saloon\Http\Connector;
+use Saloon\Traits\OAuth2\AuthorizationCodeGrant;
+use Saloon\Traits\Plugins\AcceptsJson;
+
+class GoogleOAuthConnector extends Connector implements OAuthRefresherContract
+{
+    use AcceptsJson;
+    use AuthorizationCodeGrant;
+
+    public function __construct(protected array $scopes) {}
+
+    public function resolveBaseUrl(): string
+    {
+        return '';
+    }
+
+    public static function fromService(Service $service): self
+    {
+        return self::make($service->scopes->pluck('scope_value')->toArray());
+    }
+
+    /**
+     * The OAuth2 configuration
+     */
+    protected function defaultOauthConfig(): OAuthConfig
+    {
+        return OAuthConfig::make()
+            ->setClientId(config('services.google.client_id'))
+            ->setClientSecret(config('services.google.client_secret'))
+            ->setRedirectUri(config('services.google.redirect'))
+            ->setDefaultScopes($this->scopes)
+            ->setAuthorizeEndpoint(config('services.google.auth_url'))
+            ->setTokenEndpoint(config('services.google.token_url'));
+    }
+}

--- a/app/Http/Integrations/OAuthToken/OAuthRefresherContract.php
+++ b/app/Http/Integrations/OAuthToken/OAuthRefresherContract.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Author: Marc Malha
+ * Version: 1.0
+ */
+
+namespace App\Http\Integrations\OAuthToken;
+
+use App\Models\Service;
+use Saloon\Contracts\OAuthAuthenticator;
+use Saloon\Http\Response;
+
+interface OAuthRefresherContract
+{
+    public static function fromService(Service $service): self;
+
+    public function refreshAccessToken(OAuthAuthenticator|string $refreshToken, bool $returnResponse = false, ?callable $requestModifier = null): OAuthAuthenticator|Response;
+}

--- a/app/Http/Integrations/Workflow/Exceptions/OAuthTokenExpiredException.php
+++ b/app/Http/Integrations/Workflow/Exceptions/OAuthTokenExpiredException.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Author: Marc Malha
+ * Version: 1.0
+ */
+
+namespace App\Http\Integrations\Workflow\Exceptions;
+
+use RuntimeException;
+
+class OAuthTokenExpiredException extends RuntimeException
+{
+    public static function make(): self
+    {
+        return new self('OAuth token is expired. Please subscribe to service again on "My Services" page');
+    }
+}

--- a/app/Listeners/RefreshOAuthToken.php
+++ b/app/Listeners/RefreshOAuthToken.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\WorkflowActionTriggered;
+
+class RefreshOAuthToken
+{
+    public function handle(WorkflowActionTriggered $event): void
+    {
+        $action = $event->action;
+
+        $service = $action->serviceAction->service;
+        $user = $action->workflow->user;
+        /** @var \App\Models\ServiceSubscription $serviceSubscription */
+        $serviceSubscription = $user->serviceSubscriptions()
+            ->where('service_id', $action->serviceAction->service->id)
+            ->first();
+
+        $oauthToken = $serviceSubscription->oauthToken;
+        $refreshToken = $oauthToken->refresh_token;
+
+        if (empty($refreshToken) || ! $oauthToken->expired()) {
+            return;
+        }
+
+        $serviceConfigAccessor = 'services.'.$service->socialite_driver_identifier;
+
+        /** @var \App\Http\Integrations\OAuthToken\OAuthRefresherContract $tokenRefresherClass */
+        $tokenRefresherClass = config($serviceConfigAccessor.'.token_refresher');
+
+        $tokenRefresherConnector = $tokenRefresherClass::fromService($service);
+
+        $res = $tokenRefresherConnector->refreshAccessToken($refreshToken, returnResponse: true);
+
+        $accessTokenAttributeName = config($serviceConfigAccessor.'.refresh_token_response_data.access_token');
+        $expiresInAttributeName = config($serviceConfigAccessor.'.refresh_token_response_data.expires_in');
+        $oauthToken->update([
+            'value' => $res->json($accessTokenAttributeName),
+            'expires_at' => now()->addSeconds($res->json($expiresInAttributeName)),
+        ]);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -8,12 +8,19 @@
 namespace App\Providers;
 
 use App\Actions\WorkflowAction\CreateWorkflowActionHistory;
+use App\Actions\WorkflowAction\ExecuteWorkflowAction;
 use App\Events\WorkflowAction\WorkflowActionExecuted;
+use App\Events\WorkflowActionTriggered;
+use App\Listeners\RefreshOAuthToken;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
 {
     protected $listen = [
+        WorkflowActionTriggered::class => [
+            RefreshOAuthToken::class,
+            ExecuteWorkflowAction::class,
+        ],
         WorkflowActionExecuted::class => [
             CreateWorkflowActionHistory::class,
         ],

--- a/config/services.php
+++ b/config/services.php
@@ -42,6 +42,14 @@ return [
     'google' => [
         'auth_url' => 'https://accounts.google.com/o/oauth2/v2/auth',
         'token_url' => 'https://oauth2.googleapis.com/token',
+        'client_id' => env('GOOGLE_CLIENT_ID'),
+        'client_secret' => env('GOOGLE_CLIENT_SECRET'),
+        'redirect' => env('GOOGLE_REDIRECT_URI'),
+        'token_refresher' => \App\Http\Integrations\OAuthToken\Connectors\GoogleOAuthConnector::class,
+        'refresh_token_response_data' => [
+            'access_token' => 'access_token',
+            'expires_in' => 'expires_in',
+        ],
         'calendar' => [
             'base_url' => 'https://www.googleapis.com/calendar/v3',
             'user_info_url' => 'https://openidconnect.googleapis.com/v1/userinfo',
@@ -54,9 +62,6 @@ return [
                 'https://www.googleapis.com/auth/calendar.events',
             ],
         ],
-        'client_id' => env('GOOGLE_CLIENT_ID'),
-        'client_secret' => env('GOOGLE_CLIENT_SECRET'),
-        'redirect' => env('GOOGLE_REDIRECT_URI'),
     ],
 
 ];


### PR DESCRIPTION
Fix: return 404 when a user is subscribed to a service whose refresh token is expired
Chore: dispatch WorkflowActionTriggered instead of running ExecuteWorkflowAction
Chore: add GoogleOAuthConnector and adapt config